### PR TITLE
Added /dist/ to the split.js unpkg path to make it work

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <!-- split.js -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
-    <script src="https://unpkg.com/split.js/split.min.js"></script>
+    <script src="https://unpkg.com/split.js/dist/split.min.js"></script>
 
     <link rel="stylesheet" href="../static/style.css">
     <script src="../static/app.js"></script>


### PR DESCRIPTION
Hi. Maybe they changed the convention at unpkg since the last change in your repo.