### PR TITLE
Adds steps to run inside a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.8
+
+# Download cache lists and install minimal versions
+RUN apt-get update && \
+    apt-get -yq install --no-install-recommends pipenv && \
+    # Clean up anything not needed to minimize image size and remove cache lists
+    apt-get autoremove -yq && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy in files
+COPY . .
+
+# Install using system pip
+RUN pipenv install --system
+
+# Define port we are listening on
+EXPOSE 5001
+
+# App to run
+ENTRYPOINT [ "python" ]
+
+# Arguments to app
+CMD [ "main.py" ]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ The app works as intended and is mostly done. What could/should be improved is r
 - Navigate to http://127.0.0.1:5001 in your browser
 - Try the examples, or paste your own data and templates
 
+### Running with Docker and docker-compose
+
+- Install Docker and docker-compose
+- `docker-compose up -d`
+- Navigate to http://127.0.0.1:5001 in your browser
+- `docker-compose down` stops the container
+
 ## Acknowledgements
 
 - [Attumm](https://github.com/Attumm) provided [tutorial examples](https://github.com/Attumm/textfsm_tutorial)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  textfsm-workbench:
+    build:
+      context: .
+    ports:
+      - 5001:5001

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import textfsm
 from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit
 
-BIND, HOST, PORT = "127.0.0.1", "127.0.0.1", 5001
+BIND, HOST, PORT = "0.0.0.0", "0.0.0.0", 5001
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "secret!"

--- a/static/style.css
+++ b/static/style.css
@@ -95,6 +95,7 @@ body {
 .split.split-horizontal,
 .gutter.gutter-horizontal {
   height: 100%;
+  width: 50%;
   float: left;
 }
 


### PR DESCRIPTION
- Added the steps to build it inside of a docker container instead of requiring a specific python and pipenv to be installed on the local machine.
- I changed the IP it listens on to `0.0.0.0` so it could work inside the container.
- The site wasn't rendering correctly (it was all bunched up) so I added a 50% width to the split container css settings.

Let me know if you have any feedback.