### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ def parse_textfsm(data, template):
         for state, rules in fsm.states.items()
         for rule in rules
     )
-    records = fsm.ParseText(data.strip())
+    records = fsm.ParseText(data.rstrip())
     return [dict(zip(fsm.header, record)) for record in records], regexes
 
 


### PR DESCRIPTION
The strip was pulling out important white space when parsing Cisco Command Outputs. Changed it to just remove trailing whitespace so it operates more inline with how it would when used in the wild. 